### PR TITLE
remove posibility to show stale elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The extension can be installed through the [Chrome Web Store](https://chrome.goo
 - Optional to show badge in GitHub favicon if new items
 - Loads fast, only 85kb
 - Works across multiple tabs
-- Color coding of items based on status (Approved, Closed or Stale)
+- Color coding of items based on status (Approved, Closed)
 
 ## Screenshots
 ![](images/screen1.png)

--- a/src/background/js/defaultSettings.json
+++ b/src/background/js/defaultSettings.json
@@ -2,7 +2,6 @@
     "token": null,
     "autoUpdate": true,
     "autoRefresh": 60,
-    "timeBeforeStale": 24,
     "listItemOfType": "all",
     "numberOfItems": 4,
     "updateFavicon": true,

--- a/src/content-script/components/Repositories/item.jsx
+++ b/src/content-script/components/Repositories/item.jsx
@@ -29,19 +29,12 @@ export default function Item (props) {
     )
   }
 
-  const isStale = () => {
-    if (settings.timeBeforeStale === 0) return ''
-
-    const timeNow = new Date(updatedAt).getTime()
-    const staleHoursInMS = settings.timeBeforeStale * 3600000 // One hour is 3600000ms
-    return (Date.now() - timeNow) < staleHoursInMS ? '' : 'STALE'
-  }
-
   const toggleRead = () => {
     port.postMessage({ type: 'toggleRead', id })
   }
 
-  const status = reviewStatus || isStale()
+  // If we dont have a review of this element yet, then we set it to default color
+  const status = reviewStatus || 'DEFAULT'
 
   const timeAgo = settings.sortBy === 'CREATED_AT'
     ? `created ${ago(createdAt)} ago`

--- a/src/content-script/components/Settings/index.jsx
+++ b/src/content-script/components/Settings/index.jsx
@@ -92,7 +92,7 @@ export default class Settings extends React.Component {
 
   render () {
     const { rateLimit } = this.props
-    const { repos, listItemOfType, numberOfItems, autoRefresh, updateFavicon, token, timeBeforeStale, sortBy } = this.state
+    const { repos, listItemOfType, numberOfItems, autoRefresh, updateFavicon, token, sortBy } = this.state
 
     const remaing = rateLimit
       ? <em>({rateLimit.remaining} requests left of {rateLimit.limit}. Resets in {until(rateLimit.resetAt)})</em>
@@ -157,18 +157,6 @@ export default class Settings extends React.Component {
             </label>
 
             <label>
-              Hours before an item is marked as stale/yellow (0=never)
-              <input
-                type='number'
-                name='timeBeforeStale'
-                min='0'
-                value={timeBeforeStale}
-                onChange={this.handleInputChange}
-                onBlur={this.validateInput}
-              />
-            </label>
-
-            <label>
               <input
                 type='checkbox'
                 name='updateFavicon'
@@ -184,7 +172,8 @@ export default class Settings extends React.Component {
                 name='token'
                 value={token}
                 onChange={this.handleInputChange}
-                placeholder='Access token' />
+                placeholder='Access token'
+              />
             </label>
 
             {remaing}

--- a/src/content-script/css/index.scss
+++ b/src/content-script/css/index.scss
@@ -40,7 +40,7 @@ body {
         background: $red !important;
     }
 
-    .STALE, .DEFAULT {
+    .DEFAULT {
         background: $yellow !important;
     }
 


### PR DESCRIPTION
Removes the possibility to color code stale elements in a spesific way. I think its just fine to always show all elements with a default color, and then only color-code elements if they are approved